### PR TITLE
fix method select compatible with collective

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -108,15 +108,16 @@ class FormBuilder extends IlluminateFormBuilder
      * @param  string $selected
      * @param array $selectAttributes
      * @param array $optionsAttributes
+     * @param array $optgroupsAttributes
      * @return string
      */
-    public function select($name, $list = [], $selected = null, array $selectAttributes = [], array $optionsAttributes = [])
+    public function select($name, $list = [], $selected = null, array $selectAttributes = [], array $optionsAttributes = [], array $optgroupsAttributes = [])
     {
         $selectAttributes = $this->appendClassToOptions('form-control', $selectAttributes);
 
         // Call the parent select method so that Laravel can handle
         // the rest of the select set up.
-        return parent::select($name, $list, $selected, $selectAttributes, $optionsAttributes);
+        return parent::select($name, $list, $selected, $selectAttributes, $optionsAttributes, $optgroupsAttributes);
     }
 
     /**


### PR DESCRIPTION
Fixing error on "/var/www/app/vendor/rdehnhardt/html/src/FormBuilder.php" 

> "Declaration of Rdehnhardt\Html\FormBuilder::select($name, $list = Array, $selected = NULL, array $selectAttributes = Array, array $optionsAttributes = Array) should be compatible with Collective\Html\FormBuilder::select($name, $list = Array, $selected = NULL, array $selectAttributes = Array, array $optionsAttributes = Array, array $optgroupsAttributes = Array) (View: /var/www/app/resources/views/auth/login.blade.php)"
