### PR TITLE
fix method select compatible with collective

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -108,9 +108,10 @@ class FormBuilder extends IlluminateFormBuilder
      * @param  string $selected
      * @param array $selectAttributes
      * @param array $optionsAttributes
+     * @param array $optgroupsAttributes
      * @return string
      */
-    public function select($name, $list = [], $selected = null, array $selectAttributes = [], array $optionsAttributes = [])
+    public function select($name, $list = [], $selected = null, array $selectAttributes = [], array $optionsAttributes = [], array $optgroupsAttributes = [])
     {
         $selectAttributes = $this->appendClassToOptions('form-control', $selectAttributes);
 


### PR DESCRIPTION
Fixing error on "/var/www/app/vendor/rdehnhardt/html/src/FormBuilder.php"

"Declaration of Rdehnhardt\Html\FormBuilder::select($name, $list = Array, $selected = NULL, array $selectAttributes = Array, array $optionsAttributes = Array) should be compatible with Collective\Html\FormBuilder::select($name, $list = Array, $selected = NULL, array $selectAttributes = Array, array $optionsAttributes = Array, array $optgroupsAttributes = Array) (View: /var/www/app/resources/views/auth/login.blade.php)"